### PR TITLE
Fix gettoken auth bypass

### DIFF
--- a/web/cdb.php
+++ b/web/cdb.php
@@ -2428,7 +2428,10 @@ try{
 		}
 	}
 	else if( $action == 'gettoken' && isset( $_REQUEST['key'] ) ) {
-		echo hash( 'md5', 'ChessDB' . $_SERVER['REMOTE_ADDR'] . $_REQUEST['key'] );
+		if( hash_equals( $MASTER_PASSWORD, $_REQUEST['key'] ) )
+			echo hash( 'md5', 'ChessDB' . $_SERVER['REMOTE_ADDR'] . $MASTER_PASSWORD );
+		else
+			echo 'tokenerror';
 	}
 	else if( $action == 'getip' ) {
 		echo $_SERVER['REMOTE_ADDR'];

--- a/web/chessdb.php
+++ b/web/chessdb.php
@@ -2927,7 +2927,10 @@ try{
 		}
 	}
 	else if( $action == 'gettoken' && isset( $_REQUEST['key'] ) ) {
-		echo hash( 'md5', 'ChessDB' . $_SERVER['REMOTE_ADDR'] . $_REQUEST['key'] );
+		if( hash_equals( $MASTER_PASSWORD, $_REQUEST['key'] ) )
+			echo hash( 'md5', 'ChessDB' . $_SERVER['REMOTE_ADDR'] . $MASTER_PASSWORD );
+		else
+			echo 'tokenerror';
 	}
 	else if( $action == 'getip' ) {
 		echo $_SERVER['REMOTE_ADDR'];


### PR DESCRIPTION
Validate key against master password using hash_equals() before returning token. Returns tokenerror for invalid keys, preventing oracle attacks.